### PR TITLE
Import shutter silencing on iOS

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -2,6 +2,7 @@ package com.mrousavy.camera
 
 import android.annotation.SuppressLint
 import android.hardware.camera2.*
+import android.media.MediaActionSound
 import android.util.Log
 import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.core.ImageCapture
@@ -61,6 +62,7 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
     // TODO enableAutoDistortionCorrection
   }
   val skipMetadata = if (options.hasKey("skipMetadata")) options.getBoolean("skipMetadata") else false
+  val disableShutterSound = if (options.hasKey("disableShutterSound")) options.getBoolean("disableShutterSound") else false
 
   val camera2Info = Camera2CameraInfo.from(camera!!.cameraInfo)
   val lensFacing = camera2Info.getCameraCharacteristic(CameraCharacteristics.LENS_FACING)
@@ -70,6 +72,9 @@ suspend fun CameraView.takePhoto(options: ReadableMap): WritableMap = coroutineS
       Log.d(CameraView.TAG, "Taking picture...")
       val startCapture = System.nanoTime()
       val pic = imageCapture!!.takePicture(takePhotoExecutor)
+      if(!disableShutterSound) {
+        takePhotoSound!!.play(MediaActionSound.SHUTTER_CLICK)
+      }
       val endCapture = System.nanoTime()
       Log.i(CameraView.TAG_PERF, "Finished image capture in ${(endCapture - startCapture) / 1_000_000}ms")
       pic

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.hardware.camera2.*
+import android.media.MediaActionSound
 import android.util.Log
 import android.util.Range
 import android.view.*
@@ -120,6 +121,7 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   internal val previewView: PreviewView
   private val cameraExecutor = Executors.newSingleThreadExecutor()
   internal val takePhotoExecutor = Executors.newSingleThreadExecutor()
+  internal val takePhotoSound = MediaActionSound()
   internal val recordVideoExecutor = Executors.newSingleThreadExecutor()
   internal var coroutineScope = CoroutineScope(Dispatchers.Main)
 
@@ -251,6 +253,8 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
         reactContext.removeLifecycleEventListener(this)
       }
     })
+
+    takePhotoSound.load(MediaActionSound.SHUTTER_CLICK)
   }
 
   override fun onConfigurationChanged(newConfig: Configuration?) {

--- a/example/src/views/CaptureButton.tsx
+++ b/example/src/views/CaptureButton.tsx
@@ -65,6 +65,7 @@ const _CaptureButton: React.FC<Props> = ({
       flash: flash,
       quality: 90,
       skipMetadata: true,
+      disableShutterSound: true,
     }),
     [flash],
   );

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -104,10 +104,7 @@ extension CameraView {
       }
 
       // disableShutterSound
-      var disableShutterSound = false
-      if let _disableShutterSound = options["disableShutterSound"] as? Bool{
-        disableShutterSound = _disableShutterSound
-      }
+      let disableShutterSound = (options["disableShutterSound"] as? Bool) ?? false
 
       photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise, disableShutterSound: disableShutterSound))
 

--- a/ios/CameraView+TakePhoto.swift
+++ b/ios/CameraView+TakePhoto.swift
@@ -103,7 +103,13 @@ extension CameraView {
         photoSettings.isAutoContentAwareDistortionCorrectionEnabled = enableAutoDistortionCorrection
       }
 
-      photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise))
+      // disableShutterSound
+      var disableShutterSound = false
+      if let _disableShutterSound = options["disableShutterSound"] as? Bool{
+        disableShutterSound = _disableShutterSound
+      }
+
+      photoOutput.capturePhoto(with: photoSettings, delegate: PhotoCaptureDelegate(promise: promise, disableShutterSound: disableShutterSound))
 
       // Assume that `takePhoto` is always called with the same parameters, so prepare the next call too.
       photoOutput.setPreparedPhotoSettingsArray([photoSettings], completionHandler: nil)

--- a/ios/PhotoCaptureDelegate.swift
+++ b/ios/PhotoCaptureDelegate.swift
@@ -14,11 +14,20 @@ private var delegatesReferences: [NSObject] = []
 
 class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
   private let promise: Promise
+  private let disableShutterSound: Bool
 
-  required init(promise: Promise) {
+  required init(promise: Promise, disableShutterSound: Bool = false) {
     self.promise = promise
+    self.disableShutterSound = disableShutterSound
     super.init()
     delegatesReferences.append(self)
+  }
+
+  func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+    if self.disableShutterSound {
+      // dispose system shutter sound
+      AudioServicesDisposeSystemSoundID(1108)
+    }
   }
 
   func photoOutput(_: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {

--- a/src/PhotoFile.ts
+++ b/src/PhotoFile.ts
@@ -46,6 +46,14 @@ export interface TakePhotoOptions {
    * @platform Android
    */
   skipMetadata?: boolean;
+  /**
+   * When set to `true`, There is no shutter sound.
+   *
+   * @default false
+   *
+   * @platform iOS
+   */
+  disableShutterSound?: boolean;
 }
 
 /**

--- a/src/PhotoFile.ts
+++ b/src/PhotoFile.ts
@@ -50,8 +50,6 @@ export interface TakePhotoOptions {
    * When set to `true`, There is no shutter sound.
    *
    * @default false
-   *
-   * @platform iOS
    */
   disableShutterSound?: boolean;
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
